### PR TITLE
mistake correction

### DIFF
--- a/Chapter04/4.6 BlackJack with First visit MC.ipynb
+++ b/Chapter04/4.6 BlackJack with First visit MC.ipynb
@@ -249,8 +249,8 @@
     " \n",
     "    for ax in ax1, ax2:\n",
     "        ax.set_zlim(-1, 1)\n",
-    "        ax.set_ylabel('player sum')\n",
-    "        ax.set_xlabel('dealer showing')\n",
+    "        ax.set_ylabel('dealer showing')\n",
+    "        ax.set_xlabel('player sum')\n",
     "        ax.set_zlabel('state-value')\n",
     "        "
    ]


### PR DESCRIPTION
The labels of X-axis and Y-axis were mistaken for each other.

This file should be re-runned so that the correct figure can be generated.